### PR TITLE
Windows support

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -1,13 +1,11 @@
-# Docker Based Django Girls Tutorial Starter
+# Docker Based Django Girls Tutorial Starter - Windows Edition
 
 In order to simplify the setup for [Django Girls workshops][tutorial], let's use
 Docker to set up most of our development environment.
 
-Windows users should refer to [README.windows.md](README.windows.md).
-
-**Caveat**: These instructions have been tested thoroughly on macOS, and should
-work just as well on most Linux based systems. Feel free to experiment with
-Windows and make pull requests or suggestions.
+**Caveat**: These instructions have been tested thoroughly on Windows 10 and
+Windows 7. They should work just as well on Windows 8 and _possibly_ Windows
+Vista.
 
 
 ## Installation
@@ -15,20 +13,53 @@ Windows and make pull requests or suggestions.
 Instead of following the directions in [Django Girls Tutorial
 Installation][installation], follow these setup instructions instead.
 
-1.  Install Docker Community Edition from the [Docker Store][]. Follow the
-    instructions for your specific operating system.
+
+### Install Docker
+
+1.  Download [Docker Toolbox][Docker Toolbox]. The
+download link you want is the topmost `.exe` file on the release page. It
+should have a name like `DockerToolbox-19.03.1.exe`.
+
+1.  Run the Docker Toolbox installer. Use the default options for each
+installation step.
+
+1.  There should now be a shortcut named **Docker Quickstart Terminal** on
+your Desktop. Double-click that. A command prompt will appear and output a
+bunch of text.
+
+    1.  If the Docker Quickstart Terminal seems to stop with an error message,
+        try simply closing it and running it again.
+
+    1.  At several points, you will be prompted to give the Terminal
+        permission to perform various setup tasks the first time you run it.
+
+    1.  When this setup step has completed, you should see a message similar to
+        this:
+
+        ```
+        docker is configured to use the default machine with IP 192.168.99.100
+        For help getting started, check the docs at https://docs.docker.com
+        ```
+
+    1. Close the Docker Quickstart Terminal
+
 1.  Sign up for a free [GitHub][] account, if you don't have one already. If you
     do have an account, make sure you can login with your username and password.
+
 1.  Make a copy of this repo into your own account by [forking this repo][fork].
     To do this, click on the "Fork" button at the top of this page.
+
 1.  Take a little time to read through "[Introduction to the command-line
     interface][cli-intro]", so you can be familiar with how to use your command
     line interface ("CLI").
+
 1.  Open a CLI window to setup the project:
-    ```sh
-    cd /tmp
-    curl -OL https://cdn.jsdelivr.net/gh/gsong/my-first-blog/setup.sh
-    source setup.sh
+    ```
+    cd %TMP%
+
+    powershell -command "$url='https://gist.githubusercontent.com/mike-ce/8e9a9293990567474e69fbaa423b8e84/raw/c9071c4227bd1098d727b51c3e68e8fa1e8703a5/setup.cmd';$dest='setup.cmd';echo `n`n'Downloading. Please wait...';(New-Object System.Net.WebClient).DownloadFile($url, $dest); echo `n`n'Done!'"
+
+    setup.cmd
     ```
 
 1.  [Install a code editor][code-editor].
@@ -42,8 +73,8 @@ Installation][installation], follow these setup instructions instead.
 
 1.  [Create a PythonAnywhere account][pa-account].
 
-These steps will set up your project in `${HOME}/src/djangogirls`—in other
-words, the `src/djangogirls` subdirectory in your home directory.
+These steps will set up your project in `%USERPROFILE%/src/djangogirls`—in other
+words, the `src/djangogirls` subdirectory in your user directory.
 
 🎉 You're ready to start the tutorial! Continue with [How the Internet
 works][internet]. Note some minor changes you'll have to keep in mind as you
@@ -64,8 +95,8 @@ and another to run your web server.
 
 1.  Open up a CLI window
 1.  Navigate to the project directory
-    ```sh
-    cd ${HOME}/src/djangogirls
+    ```
+    cd %USERPROFILE%/src/djangogirls
     ```
 
 1.  Start an interactive container:
@@ -97,8 +128,11 @@ instead:
 make runserver
 ```
 
-This will start the Django web server in a container, and will behave exactly as
-described in the tutorial.
+This will start the Django web server in a container. To visit the web site
+hosted by the web server go to the URL displayed when this command is run.
+
+The `make runserver` command will otherwise behave exactly as described in the
+tutorial.
 
 ### Skip the Following Sections
 
@@ -226,7 +260,7 @@ sessions.
 
 [Atom]: https://atom.io
 [Django installation]: https://tutorial.djangogirls.org/en/django_installation/
-[Docker Store]: https://store.docker.com/search?offering=community&type=edition
+[Docker Toolbox]: https://github.com/docker/toolbox/releases
 [GitHub]: https://github.com
 [IPython]: https://ipython.org
 [Python installation]: https://tutorial.djangogirls.org/en/python_installation/

--- a/README.windows.md
+++ b/README.windows.md
@@ -71,8 +71,8 @@ bunch of text.
 
 1.  [Create a PythonAnywhere account][pa-account].
 
-These steps will set up your project in `%USERPROFILE%/src/djangogirls`—in other
-words, the `src/djangogirls` subdirectory in your user directory.
+These steps will set up your project in `%USERPROFILE%\src\djangogirls`—in other
+words, the `src\djangogirls` subdirectory in your user directory.
 
 🎉 You're ready to start the tutorial! Continue with [How the Internet
 works][internet]. Note some minor changes you'll have to keep in mind as you
@@ -94,7 +94,7 @@ and another to run your web server.
 1.  Open up a CLI window
 1.  Navigate to the project directory
     ```
-    cd %USERPROFILE%/src/djangogirls
+    cd %USERPROFILE%\src\djangogirls
     ```
 
 1.  Start an interactive container:
@@ -224,7 +224,7 @@ Use this window for any research you need to do.
 
 ### Editor
 
-Make sure your editor is rooted to `${HOME}/src/djangogirls` for convenience.
+Make sure your editor is rooted to `%USERPROFILE%\src\djangogirls` for convenience.
 Each editor will have its own way of accomplishing this.
 
 

--- a/README.windows.md
+++ b/README.windows.md
@@ -14,8 +14,6 @@ Instead of following the directions in [Django Girls Tutorial
 Installation][installation], follow these setup instructions instead.
 
 
-### Install Docker
-
 1.  Download [Docker Toolbox][Docker Toolbox]. The
 download link you want is the topmost `.exe` file on the release page. It
 should have a name like `DockerToolbox-19.03.1.exe`.

--- a/bin/print-site-url.py
+++ b/bin/print-site-url.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+
+json_src = sys.stdin.read()
+if len(json_src.strip()) > 0:
+    config = json.loads(json_src)
+    addr = config.get('Driver', {}).get('IPAddress')
+    if addr:
+        url = "http://%s:%s/" % (addr, os.environ.get('APP_PORT', '8000'))
+        print("-" * len(url))
+        print(url)
+        print("-" * len(url))

--- a/bin/print-site-url.py
+++ b/bin/print-site-url.py
@@ -10,6 +10,10 @@ if len(json_src.strip()) > 0:
     addr = config.get('Driver', {}).get('IPAddress')
     if addr:
         url = "http://%s:%s/" % (addr, os.environ.get('APP_PORT', '8000'))
-        print("-" * len(url))
+        hr = "-" * len(url)
+        print("\n\n")
+        print(hr)
+        print("Your website's address is:")
+        print(hr)
         print(url)
-        print("-" * len(url))
+        print(hr)

--- a/make.cmd
+++ b/make.cmd
@@ -3,11 +3,16 @@
 set target=%1
 
 if /i %target%==runserver (
+  docker-machine start
+  docker-machine ssh default echo
+  docker-machine inspect | docker-compose run --rm app python bin/print-site-url.py
   docker-compose up
   exit /b
 )
 
 if /i %target%==cli (
+  docker-machine start
+  docker-machine ssh default echo
   docker-compose run --rm app bin/cli-command.sh
   exit /b
 )

--- a/make.cmd
+++ b/make.cmd
@@ -2,6 +2,8 @@
 
 set target=%1
 
+set HOME=%USERPROFILE%
+
 if /i %target%==runserver (
   docker-machine start
   docker-machine ssh default echo

--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,13 @@
+@echo off
+
+set target=%1
+
+if /i %target%==runserver (
+  docker-compose up
+  exit /b
+)
+
+if /i %target%==cli (
+  docker-compose run --rm app bin/cli-command.sh
+  exit /b
+)

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,0 +1,30 @@
+@echo off
+set TUTORIAL_HOME=%USERPROFILE%\src\djangogirls
+
+set /p github_username="What's your GitHub username? "
+set /p github_email="What's your GitHub email? "
+
+md %TUTORIAL_HOME%
+cd %TUTORIAL_HOME% || exit /b
+
+:: Start docker if it's not already running
+docker-machine start
+
+:: Create symlink inside the docker machine so capital drive letters will work in mount paths
+docker-machine ssh default sudo ln -sf /c /C
+
+:: Store current working directory in env var
+set current_dir=%cd%
+
+:: Convert backslashes to forward-slashes
+set current_dir=%current_dir:\=/%
+
+:: Remove ":"
+set current_dir=/%current_dir::=%
+
+docker run --rm -v %current_dir%:/root/src/djangogirls gsong/djangogirls-app git clone https://github.com/%github_username%/my-first-blog.git .
+
+(
+  echo GITHUB_USERNAME=%github_username%
+  echo GITHUB_EMAIL=%github_email%
+) > .env


### PR DESCRIPTION
- Adds a Windows-specific version of `setup.sh`.
- Adds a "fake make", a Windows batch file that emulates the targets in the main `Makefile`
- Adds a Python script, intended to be run inside the container by `make runserver`, that prints out the URL to use the access the web server
    - The site isn't be accessible via `127.0.0.1` when using Docker Toolbox, which is why this is necessary.
- Adds a Windows-specific README with more in-depth instructions for installing Docker Toolbox