### PR TITLE
Run setup and cli as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := help
 
 include Makefiles/*.mk
+include .env
 
 # Generates a help message. Borrowed from https://github.com/pydanny/cookiecutter-djangopackage.
 help: ## Display this help message
@@ -13,7 +14,7 @@ runserver: ## Start Django development server
 	docker-compose up
 
 cli: ## Start development command line interface
-	docker-compose run --rm app bin/cli-command.sh
+	docker-compose run -e "UID=$(UID)" -e "GID=$(GID)" -e "USER=$(USER)" --rm app bin/cli-command.sh
 
 build: # Build image
 	docker pull python:3.6-alpine

--- a/bin/cli-command.sh
+++ b/bin/cli-command.sh
@@ -8,4 +8,7 @@ git config --global user.email "${GITHUB_EMAIL}"
 git config --global credential.helper "cache --timeout=${GIT_CREDENTIAL_CACHE_TIMEOUT}"
 git config --global push.default simple
 
-exec /bin/bash
+adduser -u ${UID} -g ${GID} -h /root -D ${USER}
+
+exec su ${USER} -c /bin/bash
+exit $?

--- a/setup.sh
+++ b/setup.sh
@@ -23,4 +23,7 @@ docker run --rm -v "${PWD}":/root/src/djangogirls \
 cat << EOF > .env
 GITHUB_USERNAME=${github_username}
 GITHUB_EMAIL=${github_email}
+USER=${USER}
+UID=${UID}
+GID=${GID}
 EOF

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,11 @@
+#!/bin/sh
+
+set -x
+
 TUTORIAL_HOME=${HOME}/src/djangogirls
+USER=$(whoami)
+UID=$(id -u ${USER})
+GID=$(id -g ${USER})
 
 echo "What's your GitHub username?"
 read -r github_username
@@ -11,7 +18,7 @@ cd "${TUTORIAL_HOME}" || return
 
 docker run --rm -v "${PWD}":/root/src/djangogirls \
   gsong/djangogirls-app \
-  git clone https://github.com/"${github_username}"/my-first-blog.git .
+  /bin/bash -c "git clone https://github.com/${github_username}/my-first-blog.git . ; chown -R '${UID}:${GID}' /root/src/djangogirls"
 
 cat << EOF > .env
 GITHUB_USERNAME=${github_username}


### PR DESCRIPTION
On systems where file ownership matters it can be frustrating to have docker setup all files as editable by root alone. Running your editor, or anything more than is required, on the host machine with elevated privileges is an additional step and is considered bad practice.

This PR changes the setup to dynamically pull in user information from the host environment so that permissions match through to the docker environment, allowing for users to not deal with the headache of mixed permissions environments.