### PR TITLE
Fix `make cli` on Windows hosts

### DIFF
--- a/bin/cli-command.sh
+++ b/bin/cli-command.sh
@@ -8,7 +8,13 @@ git config --global user.email "${GITHUB_EMAIL}"
 git config --global credential.helper "cache --timeout=${GIT_CREDENTIAL_CACHE_TIMEOUT}"
 git config --global push.default simple
 
-adduser -u ${UID} -g ${GID} -h /root -D ${USER}
+if [ $USER = root ]; then
+  # If $USER is set to "root", which it will be when the host OS is Windows,
+  # just run without changing users.
+  exec /bin/bash
+else
+  adduser -u ${UID} -g ${GID} -h /root -D ${USER}
+  exec su ${USER} -c /bin/bash
+fi
 
-exec su ${USER} -c /bin/bash
 exit $?

--- a/docs/windows/README.md
+++ b/docs/windows/README.md
@@ -54,7 +54,7 @@ Installation][installation], follow these setup instructions instead.
     ```
     cd %TMP%
 
-    powershell -command "$url='https://gist.githubusercontent.com/mike-ce/8e9a9293990567474e69fbaa423b8e84/raw/c9071c4227bd1098d727b51c3e68e8fa1e8703a5/setup.cmd';$dest='setup.cmd';echo `n`n'Downloading. Please wait...';(New-Object System.Net.WebClient).DownloadFile($url, $dest); echo `n`n'Done!'"
+    powershell -command "$url='https://raw.githubusercontent.com/gsong/my-first-blog/master/setup.cmd';$dest='setup.cmd';echo `n`n'Downloading. Please wait...';(New-Object System.Net.WebClient).DownloadFile($url, $dest); echo `n`n'Done!'"
 
     setup.cmd
     ```

--- a/setup.cmd
+++ b/setup.cmd
@@ -27,4 +27,5 @@ docker run --rm -v %current_dir%:/root/src/djangogirls gsong/djangogirls-app git
 (
   echo GITHUB_USERNAME=%github_username%
   echo GITHUB_EMAIL=%github_email%
+  echo USER=root
 ) > .env


### PR DESCRIPTION
#5 breaks `make cli` on Windows, because it relies on a bunch of new environment variables set by `setup.sh` but **not** set by `setup.cmd`.

This PR fixes that by:
- Modifying `setup.cmd` to set `$USER` to `root`
- Modifying `cli-command.sh` to only try to change user if `$USER` is _not_ `root`
