### PR TITLE
Ubuntu and documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Instead of following the directions in [Django Girls Tutorial
 Installation][installation], follow these setup instructions instead.
 
 1.  [Install Docker][docker platforms]—follow the instructions for your specific
-    operating system. If installing on Ubuntu, see "Additional notes for
-    Ubuntu" section below.
+    operating system. If installing on Ubuntu, use you can use the
+    install-docker-ubuntu.sh script included in this repository, or see "Additional
+    notes for Ubuntu" section below.
 1.  Sign up for a free [GitHub][] account, if you don't have one already. If you
     do have an account, make sure you can login with your username and password.
 1.  Make a copy of this repo into your own account by [forking this repo][fork].

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ You'll instead see:
 ${YOUR_USERNAME}@app:~/src/djangogirls$
 ```
 
+You can leave the Docker container by entering the command `exit`.
+
 #### Run Django Web Server
 
 👉 Whenever you see mention of `python manage.py runserver`, use the following
@@ -98,6 +100,10 @@ make runserver
 
 This will start the Django web server in a container, and will behave exactly as
 described in the tutorial.
+
+If you get an error message, make sure that you're not still in the docker
+container after running `make cli`. If you are, you can either open a new
+command line tab to run `make runserver` in, or exit `make cli` with `exit`.
 
 ### Skip the Following Sections
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Instead of following the directions in [Django Girls Tutorial
 Installation][installation], follow these setup instructions instead.
 
 1.  [Install Docker][docker platforms]—follow the instructions for your specific
-    operating system.
+    operating system. If installing on Ubuntu, see "Additional notes for
+    Ubuntu" section below.
 1.  Sign up for a free [GitHub][] account, if you don't have one already. If you
     do have an account, make sure you can login with your username and password.
 1.  Make a copy of this repo into your own account by [forking this repo][fork].
@@ -47,6 +48,17 @@ words, the `src/djangogirls` subdirectory in your home directory.
 🎉 You're ready to start the tutorial! Continue with [How the Internet
 works][internet]. Note some minor changes you'll have to keep in mind as you
 follow the tutorial.
+
+### Additional notes for Ubuntu
+
+* If you're installing Docker on Ubuntu 19.10 Eoan, in the command to add the
+  Docker repository to your system, change `$(lsb_release -cs)` to `disco`.
+  This is because Docker does not have official repositories for Eoan yet, so we
+  use the repository for the previous version (Disco).
+* Make sure to follow the `Manage Docker as a non-root user` steps in
+  [Post installation for Linux][] instructions, so that you can run docker
+  without `sudo`.
+* Make sure to also install [docker-compose][] before running `make cli`.
 
 ## Changes from the Tutorial
 
@@ -237,6 +249,7 @@ sessions.
 [deploy-start-git-repo]: https://tutorial.djangogirls.org/en/deploy/#starting-our-git-repository
 [deploy]: https://tutorial.djangogirls.org/en/deploy/
 [django installation]: https://tutorial.djangogirls.org/en/django_installation/
+[docker-compose]: https://docs.docker.com/compose/install/
 [docker platforms]: https://docs.docker.com/install/#supported-platforms
 [first-project]: https://tutorial.djangogirls.org/en/django_start_project/
 [fork]: https://github.com/gsong/my-first-blog/fork
@@ -245,6 +258,7 @@ sessions.
 [internet]: https://tutorial.djangogirls.org/en/how_the_internet_works/
 [ipython]: https://ipython.org
 [pa-account]: https://tutorial.djangogirls.org/en/installation/#create-a-pythonanywhere-account
+[post installation for Linux]: https://docs.docker.com/install/linux/linux-postinstall/
 [python installation]: https://tutorial.djangogirls.org/en/python_installation/
 [sublime text]: https://www.sublimetext.com
 [tutorial]: https://tutorial.djangogirls.org/en

--- a/install-docker-ubuntu.sh
+++ b/install-docker-ubuntu.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -x
+
+# remove any old docker dependencies
+echo "Removing any old docker-related packages..."
+sudo apt-get remove docker docker-engine docker.io containerd runc docker-compose containerd.io docker-ce docker-ce-cli
+
+# add Docker repository
+echo "Adding Docker repository..."
+sudo apt-get update
+sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+# should verify the output of this against fingerprint: 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88
+# sudo apt-key fingerprint 0EBFCD88
+
+CODENAME=$(lsb_release -cs)
+
+# use disco instead of eoan, because docker repos for eoan are not ready yet
+if [ "$CODENAME" == "eoan" ]; then
+  CODENAME="disco"
+fi
+
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $CODENAME \
+   stable"
+sudo apt-get update
+
+# install the tools
+echo "Installing Docker..."
+sudo apt-get install docker-ce docker-ce-cli containerd.io
+
+# test that it runs correctly
+# sudo docker run hello-world
+
+# install docker-compose (https://docs.docker.com/compose/install/)
+echo "Installing docker-compose..."
+sudo curl -L "https://github.com/docker/compose/releases/download/1.25.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# test that it worked
+# docker-compose --version
+
+# make it possible to run docker without sudo
+echo "Adding Docker group..."
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker
+
+# test that it runs correctly
+# docker run hello-world
+
+echo "Setup done! To test, try running `docker run hello-world` and `docker-compose version`. If they both print output without errors, you're good to go!"


### PR DESCRIPTION
Fixing up the issues I ran into trying to set this up on Ubuntu.

My biggest concern is that installing Docker on Linux has a lot of steps. I threw together a script that should work in the happy case, and didn't fuss too much over it since it sounds like on this go-round laptops with Linux should already have Docker installed. Still, I wanted to get a script started and also clarify which steps in the Docker documentation are necessary.

I also tried to clarify that `make runserver` isn't run from within `make cli`, because I'm concerned about that not being clear to attendees.