### PR TITLE
Nicer error when running make inside container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,18 @@ help: ## Display this help message
 	@echo "Please use \`make <target>' where <target> is one of the following:"
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
+# This target just checks if you're executing make inside the container. If
+# you are inside the container, it fails with a hopefully helpful error
+# message. Otherwise, it silently succeeds and executes the intended target.
+assert-not-container:
+	@test -f /etc/issue && grep -q 'Alpine Linux' /etc/issue && echo "Whoops! That won't work inside the container. Type 'exit' (without the quotes), then press enter, then try that command again." && echo && echo && exit 1 || true
+
 # Tasks to be run in developer shell
 ## General Docker operations
-runserver: ## Start Django development server
+runserver: assert-not-container ## Start Django development server
 	docker-compose up
 
-cli: ## Start development command line interface
+cli: assert-not-container ## Start development command line interface
 	docker-compose run --rm app bin/cli-command.sh
 
 build: # Build image


### PR DESCRIPTION
This changes `Makefile` in a way that attempts to help address the potential issue of attendees trying to run the `make cli` and `make runserver` targets from inside the container. If either of those targets are run from inside the container, it prints out a friendly error, provides a hint about what to do instead, and exits.

I did the check inside an ugly bash one-liner because macOS (BSD) make and Linux (GNU) make have different syntax for conditions. I needed something that could work with either, which is to say something that used the lowest common denominator of Makefile syntax. So, I just fell back to using bash to actually perform the logic.

Feel free to tweak the error message to make it clearer, more friendly, and/or more helpful. I figure almost anything is better than `make: docker-compose: Command not found` or whatever.